### PR TITLE
Use referrer and item URL for resource lookup

### DIFF
--- a/background.js
+++ b/background.js
@@ -106,57 +106,20 @@ chrome.downloads.onDeterminingFilename.addListener((item, suggest) => {
       console.log("Course code found from tab ID: " + courseCode);
     }
     
-    // Try to get resource info from referrer URL
+    // Try to get resource info using referrer and item URL
     if (item.referrer) {
-      try {
-        const referrerUrl = new URL(item.referrer);
-        console.log("Trying to find resource info for referrer: " + referrerUrl.href);
-        
-        // Check for exact resource match
-        for (let pageUrl in resourcesByUrl) {
-          const resources = resourcesByUrl[pageUrl].resources;
-          console.log("Checking page URL: " + pageUrl);
-          console.log("Available resources for this page: ", resources);
-          
-          if (resources[referrerUrl.href]) {
-            const resource = resources[referrerUrl.href];
-            resourceName = resource.instanceName;
-            if (!courseCode && resource.courseCode) {
-              courseCode = resource.courseCode;
-            }
-            console.log("Resource info found from referrer URL: " + referrerUrl.href);
-            console.log("Resource name: " + resourceName);
-            break;
+      console.log("Looking up resources for referrer: " + item.referrer);
+      const pageResources = resourcesByUrl[item.referrer];
+      if (pageResources) {
+        const resources = pageResources.resources;
+        const resource = resources[item.url];
+        if (resource) {
+          resourceName = resource.instanceName;
+          if (!courseCode && resource.courseCode) {
+            courseCode = resource.courseCode;
           }
-        }
-      } catch (e) {
-        console.log("Could not parse referrer URL: " + item.referrer);
-      }
-    }
-    
-    // If not found, try to get from referrer URL pattern matching
-    if ((!courseCode || !resourceName) && item.referrer) {
-      console.log("Trying pattern matching for resource info");
-      for (let storedUrl in resourcesByUrl) {
-        if (item.referrer.startsWith(storedUrl)) {
-          const resources = resourcesByUrl[storedUrl].resources;
-          console.log("Found matching stored URL: " + storedUrl);
-          console.log("Available resources for this URL: ", resources);
-          
-          // Look for matching resource
-          for (let resourceUrl in resources) {
-            if (item.referrer === resourceUrl) {
-              const resource = resources[resourceUrl];
-              resourceName = resource.instanceName;
-              if (!courseCode && resource.courseCode) {
-                courseCode = resource.courseCode;
-              }
-              console.log("Resource info found from stored URL pattern match: " + resourceUrl);
-              console.log("Resource name: " + resourceName);
-              break;
-            }
-          }
-          if (resourceName) break;
+          console.log("Resource info found for item URL: " + item.url);
+          console.log("Resource name: " + resourceName);
         }
       }
     }


### PR DESCRIPTION
## Summary
- During download handling, find resource set by the referrer and match the actual download URL to obtain metadata
- Use the resource's instance name and course code when renaming downloaded files

## Testing
- `node --check background.js && echo "Syntax OK"`
- `node - <<'NODE'
const fs = require('fs');
const vm = require('vm');
global.chrome = {
  runtime: { onMessage: { addListener: () => {} } },
  downloads: { onDeterminingFilename: { addListener: (cb) => { global.handler = cb; } } }
};
vm.runInThisContext(fs.readFileSync('./background.js', 'utf8'));
resourcesByUrl['https://example.com/page'] = {
  resources: {
    'https://moodle.hku.hk/resourcefile.pdf': { instanceName: 'Lecture Notes', courseCode: 'COMP1234' }
  },
  timestamp: Date.now()
};
const item = {
  url: 'https://moodle.hku.hk/resourcefile.pdf',
  referrer: 'https://example.com/page',
  filename: 'file.pdf'
};
handler(item, (suggestObj) => { console.log('Suggested filename:', suggestObj.filename); });
NODE`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac84d5d5d0832eb66342534574eb8e